### PR TITLE
fix a display bug of modal box

### DIFF
--- a/homeworks/homework-05/src/main/webapp/modal-02.html
+++ b/homeworks/homework-05/src/main/webapp/modal-02.html
@@ -10,13 +10,18 @@
             box-sizing: border-box;
         }
 
+        .content {
+            font-size: 50px;
+        }
+
         /* 必须是容器背景色透明，而不是容器透明。否则容器内的元素也会透明
             因此，通过声明背景色透明度实现背景的透明*/
         /* 按窗口尺寸，绝对定位，从而实现模态框的覆盖 */
         .modal {
             width: 100vw;
             height: 100vh;
-            position: absolute;
+            /*此处应该改成fixed*/
+            position: fixed;
             background: rgba(0, 0, 0, 0.2);
             display: none;
         }
@@ -72,7 +77,9 @@
 <div class="content">
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Adipisci dicta magnam necessitatibus? A aliquid amet
         culpa cumque distinctio ducimus enim eos excepturi exercitationem inventore, obcaecati recusandae sapiente
-        sequi, temporibus unde vel voluptatem!</p>
+        sequi, temporibus unde vel voluptatem!
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab animi aperiam commodi dignissimos eligendi eum eveniet illo unde voluptates? Aperiam architecto aspernatur, aut consectetur delectus dignissimos distinctio doloribus earum error explicabo fuga hic illo illum iste itaque labore molestias perspiciatis quae quasi quisquam quos ratione sed similique tempore voluptas? Dolorem dolorum explicabo in labore libero magnam numquam quae quia. A ab, ad aliquam animi consequatur cum eius eos eveniet id inventore laboriosam mollitia nam nisi nulla numquam optio possimus quo reiciendis repellendus reprehenderit sequi sit tempore veniam veritatis vero? Qui.
+    </p>
     <!-- 通过自定义属性，实现与modal的绑定 -->
     <button data-target="m1">点击激活模态框</button>
 </div>


### PR DESCRIPTION
### 老师我刚才把你的代码克隆到本地运行之后发现模态框的显示有点问题
![模态框bug](https://user-images.githubusercontent.com/41418487/67278947-9fb6bd00-f4fc-11e9-9880-c8d5090bf1b0.gif)
#### 如图所示，我在内容容器里多加了一些文字，并把字体变大，点击按钮，模态框弹出后不是正好占据整个屏幕，而是多出来一小块，而且弹出来的位置是在屏幕的上边。

#### 我把模态框容器的position属性改成fixed之后，问题解决了，因为fixed同样可以实现悬浮效果，而fixed是基于浏览器窗口进行定位。
![image](https://user-images.githubusercontent.com/41418487/67279449-9aa63d80-f4fd-11e9-805f-4bf05f655cbe.png)

